### PR TITLE
Fix invalid bom format

### DIFF
--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -56,7 +56,8 @@ python do_dependencytrack_collect() {
             sbom["components"].append({
                 "name": names[index],
                 "version": version,
-                "cpe": cpe
+                "cpe": cpe,
+                "type": "application"
             })
 
     # write it back to the deploy directory


### PR DESCRIPTION
According to https://cyclonedx.org/docs/1.4/json/#components_items_type each component must have a type defined for a bom to be valid cyclonedx. This definition was previously missing from the generated bom.

Since 4.11 of DT (https://github.com/DependencyTrack/dependency-track/pull/3522) uploaded boms are validated against the cyclonedx schema, thus causing meta-dependencytrack to fail.